### PR TITLE
[FIX] latexindent設定を修正してreplaceとmodifyLineBreaks機能を有効化

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -69,6 +69,8 @@
         "latex-workshop.view.pdf.viewer": "tab",
         "latex-workshop.formatting.latex": "latexindent",
         "latex-workshop.formatting.latexindent.args": [
+          "-r", // replace機能を有効化
+          "-m", // modifyLineBreaks機能を有効化
           "%TMPFILE%",
           "-c=%DIR%/",
           "-l=%WORKSPACE_FOLDER%/.latexindent.yaml"

--- a/.latexindent.yaml
+++ b/.latexindent.yaml
@@ -12,6 +12,7 @@ indentPreamble: 1
 # 行末の不要な空白を自動で削除する
 removeTrailingWhitespace:
   beforeProcessing: 1
+  afterProcessing: 1
 # 独立した行にあるコメントを、周囲のコードと同じレベルにインデントする
 indentFirstLineComments: 1
 
@@ -19,11 +20,6 @@ indentFirstLineComments: 1
 # 改行の調整 (バージョン管理との親和性向上)
 # ------------------------------------------------------------------
 modifyLineBreaks:
-  # 1行1文にすることで、Gitの差分（diff）を読みやすくする
-  oneSentencePerLine:
-    manipulateSentences: 1
-    sentencesFollow:
-      - "sentence"
   # 環境（\begin{} ... \end{}）の開始・終了を独立した行にする
   environments:
     BeginStartsOnOwnLine: 1
@@ -102,16 +98,13 @@ substitutions:
     r: "$1"
 
 # ------------------------------------------------------------------
-# コード折りたたみ支援
+# 文字置換設定
 # ------------------------------------------------------------------
-addContinuationIndentation:
-  # このリストにある環境の前後にコメントを自動挿入する
-  environments:
-    figure: 1
-    figure*: 1
-    table: 1
-    table*: 1
-    tikzpicture: 1
+replacements:
+  - this: "、"
+    that: "，"
+  - this: "。"
+    that: "．"
 
 # ------------------------------------------------------------------
 # 特殊な環境の定義


### PR DESCRIPTION
## 概要

Issue #12で報告されたlatexindentの設定問題を修正し、replace等の機能が正常に動作するようにしました。

## 修正内容

### 1. VS Code設定の修正（`.devcontainer/devcontainer.json`）
- `latex-workshop.formatting.latexindent.args`に以下のオプションを追加：
  - `"-r"`: replace機能を有効化（日本語句読点の置換等）
  - `"-m"`: modifyLineBreaks機能を有効化（改行の調整）

### 2. latexindent設定の修正（`.latexindent.yaml`）
- ✅ **replacements設定を追加**: 日本語句読点の置換（「、」→「，」、「。」→「．」）
- ✅ **removeTrailingWhitespace設定を完全化**: `afterProcessing: 1`を追加
- ✅ **1文1行設定を削除**: 長い文章の2行分割が1行にまとめられることを防止
- ✅ **不要な折りたたみ設定を削除**: `addContinuationIndentation`を削除

## テスト結果

包括的なテストを実施し、以下の機能が正常に動作することを確認済み：

- ✅ **句読点置換**: 日本語句読点が正しく置換される
- ✅ **インデント**: 4スペースインデントが正常動作
- ✅ **環境整形**: itemize、align等の環境が正しく整形される
- ✅ **数式アライメント**: `&`の前後のスペースが正常配置
- ✅ **空白処理**: 行末空白削除、複数空行圧縮が正常動作
- ✅ **2行分割保持**: 長い文章の意図的な分割が保持される

## デフォルト設定との整合性

latexindent v3.24.5のデフォルト設定と比較し、整合性を確認済み：
- 意図的な変更（4スペースインデント、日本語対応等）が適切に実装
- 全ての設定がデフォルトと矛盾なく動作

## 関連Issue

Fixes #12

## チェックリスト

- [x] 原因の特定
- [x] 修正の実装  
- [x] テストの実施
- [x] 修正の確認
- [x] デフォルト設定との整合性確認